### PR TITLE
feat: Add decision record template

### DIFF
--- a/docs/decision-records/decision-record-template.md
+++ b/docs/decision-records/decision-record-template.md
@@ -1,0 +1,51 @@
+<!--
+#######################################################################
+
+Tractus-X - Special Interest Group (SIG) Architecture
+
+Copyright (c) 2025 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This work is made available under the terms of the
+Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode.
+
+SPDX-License-Identifier: CC-BY-4.0
+
+#######################################################################
+-->
+
+# Decision Record: {{ title representing decision }}
+
+## Problem statement
+
+{{ describe the problem statement providing context where necessary }}
+
+## Evaluation criteria
+
+{{ list all criteria based on which the decision will be taken; use subsections or bullet points depending on your needs }}
+
+## Possible solutions
+
+{{ briefly summarise all possible reasonable approaches to solving the problem }}
+
+### Solution 1: {{ title summarising solution 1 }}
+
+{{ evaluate the solution based on the evaluation criteria from the previous section; include additional pros and cons where appropriate; repeat for every solution }}
+
+## Decision: {{ title summarising solution }}
+
+### Rationale
+
+{{ explain why the solution was chosen; where appropriate explain why other solutions were not chosen }}
+
+### Actions
+
+{{ list all actions which will be taken as a direct effect of this decision, e.g. creation of a repository }}
+
+### Consequences
+
+{{ list all indirect implications of the decision, e.g. deprecation of a component }}


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Add a template for future ADRs to follow a unified structure.
Template is based on the first ADR introduced with #8.

## Pre-review checks

- [ ] ~DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.~  (not applicable)
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
