### PR TITLE
chore: fixed license source code origin in connect & exchange pattern

### DIFF
--- a/docs/patterns/connect&exchange/README.md
+++ b/docs/patterns/connect&exchange/README.md
@@ -258,4 +258,4 @@ This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses
 
 - SPDX-License-Identifier: CC-BY-4.0
 - SPDX-FileCopyrightText: 2024, 2025 Contributors to the Eclipse Foundation
-- Source URL: https://github.com/eclipse-tractusx/digital-product-pass
+- Source URL: https://github.com/eclipse-tractusx/sig-architecture


### PR DESCRIPTION
## Description

I forgot to specify the correct repository, the incorrect url template was introduced by me by mistake.

Now the URL is fixed.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
