### PR TITLE
Create 0002_tractusx-edc-ranaming-to-tractusx-connector

### DIFF
--- a/docs/decision-records/0002_tractusx-edc-ranaming-to-tractusx-connector
+++ b/docs/decision-records/0002_tractusx-edc-ranaming-to-tractusx-connector
@@ -1,0 +1,72 @@
+<!--
+#######################################################################
+
+Tractus-X - Special Interest Group (SIG) Architecture
+
+Copyright (c) 2025 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This work is made available under the terms of the
+Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode.
+
+SPDX-License-Identifier: CC-BY-4.0
+
+Source URL: https://github.com/eclipse-tractusx/sig-architecture
+
+#######################################################################
+-->
+
+<!-- File name must be aligned with title. -->
+
+# 0002 Decision Record: Tractus-X EDC renaming to Tractus-X Connector
+
+## Metadata
+
+* Date: 2025-05-09
+* Dependencies: Tractus-X EDC
+* Target group: Committers & Contributors
+
+## Problem statement
+
+The [Eclipse Dataspace Connector](https://projects.eclipse.org/projects/technology.edc) project was renamed to [Eclipse Dataspace Componenents](https://projects.eclipse.org/projects/technology.edc) in early 2024 (since more than a year).
+Therefore the naming from the connector was changed from EDC, to EDC Connector, making reference to the project "Eclipse Dataspace Components" as EDC.
+The Connector is one of the components available at the static code framework provided at the Eclipse Dataspace Componenents (EDC) project, also like IdentityHub, FederatedCatalog, etc.
+
+Our current [tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc) repository is named incorrectly since it contains still the old naming of the edc project.
+Right now 
+
+
+## Evaluation criteria
+
+{{ list all criteria based on which the decision will be taken; use subsections or bullet points depending on your needs }}
+
+## Possible solutions
+
+{{ briefly summarise all possible reasonable approaches to solving the problem }}
+
+### Solution 1: {{ title summarising solution 1 }}
+
+{{ evaluate the solution based on the evaluation criteria from the previous section; include additional pros and cons where appropriate; repeat for every solution }}
+
+## Decision: {{ title summarising solution }}
+
+### Rationale
+
+{{ explain why the solution was chosen; where appropriate explain why other solutions were not chosen }}
+
+### Actions
+
+{{ list all actions which will be taken as a direct effect of this decision, e.g. creation of a repository }}
+
+### Consequences
+
+{{ list all indirect implications of the decision, e.g. deprecation of a component }}
+
+## NOTICE
+
+- SPDX-FileCopyrightText: 2025 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/sig-architecture


### PR DESCRIPTION
## Description

Renaming the tractusx-edc to tractusx-connector is important because the naming "EDC" refers to Eclipse Dataspace Components and not the connector itself. The connector is one of the products available at the framework.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Closes #14 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
